### PR TITLE
Rework UpdateResult

### DIFF
--- a/src/main/scala/com/evolutiongaming/conhub/ConHub.scala
+++ b/src/main/scala/com/evolutiongaming/conhub/ConHub.scala
@@ -37,7 +37,7 @@ object ConHub {
 
 
   trait Manage[Id, A, M] {
-    type Result = Future[UpdateResult[A]]
+    type Result = Future[UpdateResult[Conn[A, M]]]
 
     /**
       *

--- a/src/main/scala/com/evolutiongaming/conhub/UpdateResult.scala
+++ b/src/main/scala/com/evolutiongaming/conhub/UpdateResult.scala
@@ -1,24 +1,28 @@
 package com.evolutiongaming.conhub
 
-/**
-  *
-  * @param updated whether action did update the value
-  * @param value   value before the update if it was updated or current value otherwise
-  */
-final case class UpdateResult[+A](updated: Boolean = false, value: Option[A] = None)
+import com.evolutiongaming.conhub.UpdateResult.NotUpdated.Reason
+
+sealed trait UpdateResult[+C]
 
 object UpdateResult {
 
-  private val Empty = UpdateResult()
+  final case class Updated[C](previousValue: Option[C]) extends UpdateResult[C]
 
-  private val Created = UpdateResult(updated = true)
+  final case class NotUpdated[C](reason: Reason[C]) extends UpdateResult[C]
 
+  object NotUpdated {
+    sealed trait Reason[+C]
 
-  def empty[A]: UpdateResult[A] = Empty
+    object Reason {
+      final case object VersionConflict extends Reason[Nothing]
 
-  def created[A]: UpdateResult[A] = Created
+      final case object SameValue extends Reason[Nothing]
 
-  def apply[A](updated: Boolean, value: A): UpdateResult[A] = UpdateResult(updated, Some(value))
+      final case object UpdateNotRequiredByMethod extends Reason[Nothing]
 
-  def apply[A](value: A): UpdateResult[A] = UpdateResult(value = Some(value))
+      final case class UpdateNotDefinedForValue[C](previousValue: Option[C]) extends Reason[C]
+
+      final case class WrongContext[C](context: String, connection: C) extends Reason[C]
+    }
+  }
 }

--- a/src/test/scala/com/evolutiongaming/conhub/ConHubSpec.scala
+++ b/src/test/scala/com/evolutiongaming/conhub/ConHubSpec.scala
@@ -49,7 +49,7 @@ class ConHubSpec extends AnyWordSpec {
     }
 
     val conStates = new ConStates[Void, Void, Void] {
-      private val result = UpdateResult.empty[Void].future
+      private val result = UpdateResult.Updated[Conn[Void, Void]](None).future
       def values: collection.Map[Void, C] = Map.empty
       def update(id: Void, local: C.Local): Result = result
       def update(id: Void, version: Version, value: ByteVector, address: Address): Result = result


### PR DESCRIPTION
Motivation: currently UpdateResult has an `updated` flag, but it's impossible for users of Conhub to know why a certain update operation has failed.