### PR TITLE
fix SendResult handling in ConHubImpl for batch message sending

### DIFF
--- a/src/main/scala/com/evolutiongaming/conhub/ConHubImpl.scala
+++ b/src/main/scala/com/evolutiongaming/conhub/ConHubImpl.scala
@@ -130,6 +130,8 @@ object ConHubImpl extends LazyLogging {
 
         for {remoteMsgs <- Nel.opt(remoteMsgs)} sendMsgs.remote(remoteMsgs, Nil)
 
+        val cons = msgsAndCons.flatMap { case (_, cons) => cons }
+
         future map { _ => SendResult(cons) }
       }
 


### PR DESCRIPTION
Currently, this method returns all connections in SendResult instead of returning connections based on lookups. This PR fixes that.