### PR TITLE
Migrate to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1
 
       - name: build ${{ matrix.scala }}
-        run: sbt "++${{ matrix.scala }}; clean; check; coverage; test; coverageReport; coverageAggregate"
+        run: sbt "++${{ matrix.scala }}; clean; check; coverage; testFull; coverageReport; coverageAggregate"
 
       - name: upload coverage
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           file: target/out/jvm/scala-${{ matrix.scala }}/conhub/coverage-report/cobertura.xml
           format: cobertura
           flag-name: Scala ${{ matrix.scala }}
+          parallel: true
 
       - name: slack
         uses: homoluctus/slatify@master
@@ -50,3 +51,14 @@ jobs:
           type: ${{ job.status }}
           job_name: Build
           url: ${{ secrets.SLACK_WEBHOOK }}
+
+  coverage-finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: coveralls finished
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          carryforward: "Scala 2.13.18,Scala 3.3.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1
 
       - name: build ${{ matrix.scala }}
+        # SBT_LOCAL_CACHE points at an ephemeral per-run dir so the coverage compile always
+        # runs scalac; otherwise sbt 2's warm build cache serves it and never recreates the
+        # scoverage-data directory, crashing the instrumented tests at runtime.
+        env:
+          SBT_LOCAL_CACHE: ${{ runner.temp }}/sbt-local-cache
         run: sbt "++${{ matrix.scala }}; clean; check; coverage; testFull; coverageReport; coverageAggregate"
 
       - name: upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/out/jvm/scala-*/conhub/coverage-report/cobertura.xml
+          file: target/out/jvm/scala-${{ matrix.scala }}/conhub/coverage-report/cobertura.xml
           format: cobertura
           flag-name: Scala ${{ matrix.scala }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.16
+          - 2.13.18
           - 3.3.3
 
     steps:
@@ -27,14 +27,16 @@ jobs:
       - uses: sbt/setup-sbt@9d56cf12e9b58d219605e1d8bfe69a8395fedde0 # v1
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean check coverage test
+        run: sbt "++${{ matrix.scala }}; clean; check; coverage; test; coverageReport; coverageAggregate"
 
-      - name: test coverage
+      - name: upload coverage
         if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/out/jvm/scala-*/conhub/coverage-report/cobertura.xml
+          format: cobertura
+          flag-name: Scala ${{ matrix.scala }}
 
       - name: slack
         uses: homoluctus/slatify@master

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,9 @@ Compile / scalacOptions ++= {
 
 Test / fork := true
 
+// scalatest matchers (shouldEqual, etc.) are routinely used as discarded statements mid-test
+Test / scalacOptions := (Test / scalacOptions).value.filterNot(_ == "-Wnonunit-statement")
+
 publishTo := Some(Resolver.evolutionReleases)
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.14
+sbt.version=2.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,9 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
-
 // This sets the 'version' property based on the git tag during release process to publish the right version
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
+addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.1.0")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 

--- a/src/main/scala/com/evolutiongaming/conhub/ConStates.scala
+++ b/src/main/scala/com/evolutiongaming/conhub/ConStates.scala
@@ -51,7 +51,7 @@ object ConStates {
 
     val conStates = apply(states, scheduler, conSerializer, onChanged, now, connect)
 
-    scheduler.scheduleWithFixedDelay(checkConsistencyInterval, checkConsistencyInterval) {
+    val _ = scheduler.scheduleWithFixedDelay(checkConsistencyInterval, checkConsistencyInterval) {
       () => for {id <- states.values.keys} conStates.checkConsistency(id)
     }
 

--- a/src/main/scala/com/evolutiongaming/conhub/transport/SendMsg.scala
+++ b/src/main/scala/com/evolutiongaming/conhub/transport/SendMsg.scala
@@ -139,7 +139,7 @@ object SendMsg extends StrictLogging {
           logger.debug(s"$name onConnected $address")
           val channel = Channel.Connected(to = ref, from = self)
           state = state + (address -> channel)
-          context.watch(ref)
+          val _ = context.watch(ref)
           val identity = ActorIdentity("ready", Some(self))
           channel(identity)
           connected(address)


### PR DESCRIPTION
Migrate build to sbt 2.0.3: bump plugins to sbt-2-compatible versions, move coverage upload to a pinned GitHub Action, and fix lint/CI.